### PR TITLE
Automatically change provider

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -1,3 +1,8 @@
+[interval]
+# The interval at which the screen should automatically change
+# set to 0 if you don't want it to change automatically
+refresh=45
+
 [clock]
 enabled = true
 # Set this to the highest priority so it will start with the clock

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,14 +88,13 @@ pub async fn main() -> Result<()> {
     device.clear().await?;
 
     let mut scheduler = Scheduler::new(device);
+    scheduler.start(tx.clone(), rx, settings).await?;
 
     ctrlc::set_handler(move || {
         info!("Ctrl + C received, shutting down!");
         tx.send(Command::Shutdown)
             .expect("Failed to send shutdown signal!");
     })?;
-
-    scheduler.start(rx, settings).await?;
 
     #[cfg(feature = "hotkeys")]
     drop(hkm);

--- a/src/render/scheduler.rs
+++ b/src/render/scheduler.rs
@@ -153,7 +153,7 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
         let mut y = multiplex(providers, move || z.load(Ordering::SeqCst));
 
         //get the interval
-        let interval_bewteen_change = config.get_int("interval.refresh").unwrap_or(30);
+        let interval_between_change = config.get_int("interval.refresh").unwrap_or(30);
         //flag to know if auto changer is enabled
         let is_auto_change_enabled = interval_between_change != 0;
         //the interval to check wether to change the screen or not
@@ -208,7 +208,7 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
                         let current_time = Instant::now();
                         let elapsed_time = current_time - time_last_change.borrow().clone();
                         //if the last update is over 30seconds
-                        if elapsed_time > Duration::from_secs(interval_bewteen_change as u64) {
+                        if elapsed_time > Duration::from_secs(interval_between_change as u64) {
                             //change the screen
                             let _ = tx.send(Command::NextSource);
                         }

--- a/src/render/scheduler.rs
+++ b/src/render/scheduler.rs
@@ -207,7 +207,7 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
                         //get the time since the last update
                         let current_time = Instant::now();
                         let elapsed_time = current_time - time_last_change.borrow().clone();
-                        //if the last update is over 30seconds
+                        //if the last update is over the choosen interval
                         if elapsed_time > Duration::from_secs(interval_between_change as u64) {
                             //change the screen
                             let _ = tx.send(Command::NextSource);

--- a/src/render/scheduler.rs
+++ b/src/render/scheduler.rs
@@ -144,8 +144,10 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
 
         let mut y = multiplex(providers, move || z.load(Ordering::SeqCst));
         
+        //get the interval
+        let interval_bewteen_change = config.get_int("interval.refresh").unwrap_or(30);
         //flag to know if auto changer is enabled
-        let is_auto_change_enabled = config.get_int("interval.refresh").unwrap_or(1) != 0;
+        let is_auto_change_enabled = interval_between_change != 0;
         //the interval to check wether to change the screen or not
         let mut change = time::interval(
             Duration::from_secs(
@@ -201,7 +203,7 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
                         let current_time = Instant::now();
                         let elapsed_time = current_time - time_last_change.borrow().clone();
                         //if the last update is over 30seconds
-                        if elapsed_time > Duration::from_secs(config.get_int("refresh.interval").unwrap_or(30) as u64) {
+                        if elapsed_time > Duration::from_secs(interval_bewteen_change as u64) {
                             //change the screen
                             let _ = tx.send(Command::NextSource);
                         }

--- a/src/render/scheduler.rs
+++ b/src/render/scheduler.rs
@@ -151,8 +151,8 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
         //the interval to check wether to change the screen or not
         let mut change = time::interval(
             Duration::from_secs(
-                if !is_auto_change_enabled {
-                    30
+                if !is_auto_change_enabled { // this is done for performance (don't know if it actually has a big impact)
+                    300 
                 }else{
                     1
                 }

--- a/src/render/scheduler.rs
+++ b/src/render/scheduler.rs
@@ -74,6 +74,7 @@ impl<'a, T: 'a + AsyncDevice> Scheduler<'a, T> {
 
     pub async fn start(
         &mut self,
+        tx: broadcast::Sender<Command>,
         rx: broadcast::Receiver<Command>,
         mut config: Config,
     ) -> Result<()> {


### PR DESCRIPTION
This PR should change the provider every X seconds (customizable in `settings.toml`, by default it's 30 seconds if no settings are found)
this features is also disable-able (by settings 0 second in `settings.toml`)

This PR is made to aid #5 