### PR TITLE
Better images

### DIFF
--- a/settings.toml
+++ b/settings.toml
@@ -44,3 +44,4 @@ path = "images/sample_1.gif"
 # This only works if the image feature is passed in the build instructions
 # It supports all those formats : https://github.com/image-rs/image/tree/8824ab3375ddab0fd3429fe3915334523d50c532#supported-image-formats
 # (even in color, but it will only display in black and white)
+# (Hint: you can also put a folder, it will cycle through every __file__ in that folder)

--- a/src/providers/image.rs
+++ b/src/providers/image.rs
@@ -96,6 +96,8 @@ impl Images {
             }
             
             self.current_image.store(next_image, Ordering::Relaxed);
+            let next = &self.images[next_image];
+            next.set_display_time();
         }
 
         Ok(buffer)

--- a/src/providers/image.rs
+++ b/src/providers/image.rs
@@ -90,7 +90,7 @@ impl Images {
         //draw and detect if the gif/image has ended
         let has_ended = image_data.draw(&mut buffer);
 
-        if has_ended {
+        if has_ended && !self.images.len() == 1 {
             let mut next_image = image + 1;
             let has_no_next_image = next_image >= self.images.len();
 

--- a/src/providers/image.rs
+++ b/src/providers/image.rs
@@ -10,7 +10,7 @@ use embedded_graphics::geometry::Point;
 use futures::Stream;
 use linkme::distributed_slice;
 use log::info;
-use std::fs::File;
+use std::{fs::{File, self}, sync::atomic::{AtomicUsize, Ordering}, path::Path};
 use tokio::{
     time,
     time::{Duration, MissedTickBehavior},
@@ -26,36 +26,83 @@ fn register_callback(config: &Config) -> Result<Box<dyn ContentWrapper>> {
     info!("Registering Image display source.");
 
     let image_path = config.get_str("image.path").unwrap_or_else(|_| String::from("images/sample_1.gif"));
-    let image_file = File::open(&image_path);
+    let mut images = Vec::new();
 
-    let image = match image_file {
-        Ok(file) => image::ImageRenderer::new(Point::new(0, 0), Point::new(128, 40), file),
-        Err(err) => {
-            log::error!("Failed to open the image '{}': {}", image_path, err);
+    if Path::new(&image_path).is_dir(){
 
-            // Use the `new_error` function to create an error GIF
-            image::ImageRenderer::new_error(Point::new(0, 0), Point::new(128, 40))
+        for file in fs::read_dir(image_path).unwrap(){
+            let file_path = file.unwrap().path();    
+            let image_file = File::open(file_path.clone());
+
+            let image = match image_file {
+                Ok(file) => image::ImageRenderer::new(Point::new(0, 0), Point::new(128, 40), file),
+                Err(err) => {
+                    log::error!("Failed to open the image '{}': {}", file_path.display(), err);
+        
+                    // Use the `new_error` function to create an error GIF
+                    image::ImageRenderer::new_error(Point::new(0, 0), Point::new(128, 40))
+                }
+            };
+            images.push(image);
         }
-    };
+    } else {
 
-    Ok(Box::new(Image { image }))
+        let image_file = File::open(&image_path);
+
+        let image = match image_file {
+            Ok(file) => image::ImageRenderer::new(Point::new(0, 0), Point::new(128, 40), file),
+            Err(err) => {
+                log::error!("Failed to open the image '{}': {}", image_path, err);
+    
+                // Use the `new_error` function to create an error GIF
+                image::ImageRenderer::new_error(Point::new(0, 0), Point::new(128, 40))
+            }
+        };
+        images.push(image);
+    }
+
+    Ok(Box::new(Images 
+        { 
+            images,
+            current_image: AtomicUsize::new(0), 
+        }
+    ))
 }
 
-pub struct Image {
-    image: image::ImageRenderer,
+pub struct Images {
+    images: Vec<image::ImageRenderer>,
+    current_image: AtomicUsize,
 }
 
-impl Image {
+impl Images {
     pub fn render(&self) -> Result<FrameBuffer> {
         let mut buffer = FrameBuffer::new();
 
-        self.image.draw(&mut buffer);
+        let image = self.current_image.load(Ordering::Relaxed);
+        //get the data for the specified frame
+        let image_data = &self.images[image];
+        //draw and detect if the gif/image has ended
+        let has_ended = image_data.draw(&mut buffer);
+
+        if has_ended {
+            let mut next_image = image + 1;
+            let has_no_next_image = next_image >= self.images.len();
+
+            if has_no_next_image {
+                //reset to frame 0
+                next_image = 0;
+            } else {
+                next_image = next_image;
+            }
+            
+            self.current_image.store(next_image, Ordering::Relaxed);
+        }
 
         Ok(buffer)
     }
 }
 
-impl ContentProvider for Image {
+impl ContentProvider for Images {
     type ContentStream<'a> = impl Stream<Item = Result<FrameBuffer>> + 'a;
 
     // This needs to be enabled until full GAT support is here

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -160,16 +160,12 @@ impl ImageRenderer {
     }
 
     pub fn fit_image(image: DynamicImage, size: Point) -> DynamicImage {
-        if image.height() > size.y as u32 {
-            let width = image.width() * size.y as u32 / image.height();
-            let height = size.y as u32;
-
-            image.resize(width, height, image::imageops::FilterType::Nearest)
-        } else if image.width() > size.x as u32 {
-            let width = size.x as u32;
-            let height = image.height() * size.x as u32 / image.width();
-
-            image.resize(width, height, image::imageops::FilterType::Nearest)
+        if image.height() > size.y as u32 || image.width() > size.x as u32 {
+            image.resize(
+                size.x as u32,
+                size.y as u32,
+                image::imageops::FilterType::Nearest,
+            )
         } else {
             image
         }

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -222,9 +222,14 @@ impl ImageRenderer {
             for frame in gif.into_frames() {
                 //TODO we do not handle if the frame isn't formatted properly!
                 if let Ok(frame) = frame {
-                    //TODO some gifs do not have delays embedded, we should use a 100 ms in that
-                    // case
-                    delays.push(Duration::from(frame.delay()).as_millis() as u16);
+                    //get the delay between this frame and the next
+                    let mut delay = Duration::from(frame.delay()).as_millis() as u16;
+                    //if no delay is set, default to 16 (to get ~60 fps)
+                    if delay == 0 {
+                        delay = 16;
+                    }
+
+                    delays.push(delay);
                     let resized = Self::fit_image(
                         DynamicImage::ImageRgba8(frame.into_buffer()),
                         Point::new(DISPLAY_WIDTH, DISPLAY_HEIGHT),

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -302,4 +302,7 @@ impl ImageRenderer {
         }
         false
     }
+    pub fn set_display_time(&self){
+        *self.time_frame_last_update.borrow_mut() = Instant::now();
+    }
 }

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -249,7 +249,7 @@ impl ImageRenderer {
                 image_width,
             ));
             delays.push(1500); // Add a default delay of 500ms for single image
-                              // rendering
+                               // rendering
         }
 
         Self {
@@ -291,6 +291,8 @@ impl ImageRenderer {
     }
 
     pub fn draw(&self, target: &mut FrameBuffer) -> bool {
+        //TODO This runs every 10ms, this doesn't need to run that fast everytime when
+        // rendering still images (so maybe we can avoid rendering each time)
         let frame = self.current_frame.load(Ordering::Relaxed);
 
         //get the data for the specified frame
@@ -329,7 +331,8 @@ impl ImageRenderer {
         }
         false
     }
-    pub fn set_display_time(&self){
+
+    pub fn set_display_time(&self) {
         *self.time_frame_last_update.borrow_mut() = Instant::now();
     }
 }

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -214,9 +214,9 @@ impl ImageRenderer {
 
         if let Ok(gif) = image::codecs::gif::GifDecoder::new(&buffer[..]) {
             //if the image is a gif
-            //NOTE we do not check for the size of each frame!
-            //We can avoid doing so since we have the Self::fit_image which will resize the
-            // frames correctly.
+
+            // We do not need to check for the size of each frame since we have the
+            // Self::fit_image which will resize the frames correctly.
 
             //we go through each frame
             for frame in gif.into_frames() {

--- a/src/render/image.rs
+++ b/src/render/image.rs
@@ -221,7 +221,7 @@ impl ImageRenderer {
                 image_height,
                 image_width,
             ));
-            delays.push(500); // Add a default delay of 500ms for single image
+            delays.push(1500); // Add a default delay of 500ms for single image
                               // rendering
         }
 


### PR DESCRIPTION
Here's a list that I want to change
- [x] center the images
- [x] handle multiple images in the folder (slideshow feature)
- [ ] Filter through every known image type (eg. let's not try to open a .odt file)
- [ ] have "animations" when changing images
- [ ] smash all the (image related) TODOs

Bonus  
- Optimisations : 
   - The resize algorithm is handled by the image crate itself
   - Won't apply the slideshow logic if there is only 1 image