### PR TITLE
Change font from ascii to iso_8859_15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 .idea/
+.env

--- a/src/providers/clock.rs
+++ b/src/providers/clock.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Local};
 use config::Config;
 use embedded_graphics::{
     geometry::Point,
-    mono_font::{ascii, MonoTextStyle},
+    mono_font::{iso_8859_15, MonoTextStyle},
     pixelcolor::BinaryColor,
     text::{renderer::TextRenderer, Baseline, Text},
     Drawable,
@@ -66,7 +66,7 @@ impl Clock {
 
         let text = local.format(format_string).to_string();
         let mut buffer = FrameBuffer::new();
-        let style = MonoTextStyle::new(&ascii::FONT_8X13_BOLD, BinaryColor::On);
+        let style = MonoTextStyle::new(&iso_8859_15::FONT_8X13_BOLD, BinaryColor::On);
         let metrics = style.measure_string(&text, Point::zero(), Baseline::Top);
         let height: i32 = (metrics.bounding_box.size.height / 2) as i32;
         let width: i32 = (metrics.bounding_box.size.width / 2) as i32;

--- a/src/providers/music.rs
+++ b/src/providers/music.rs
@@ -24,7 +24,7 @@ use crate::render::{
 use apex_music::{AsyncPlayer, Metadata, Progress};
 use config::Config;
 use embedded_graphics::{
-    mono_font::{ascii, MonoTextStyle},
+    mono_font::{iso_8859_15, MonoTextStyle},
     text::{Baseline, Text},
 };
 use futures::StreamExt;
@@ -101,7 +101,7 @@ lazy_static! {
 lazy_static! {
     static ref IDLE_TEMPLATE: FrameBuffer = {
         let mut base = *PAUSE_TEMPLATE;
-        let style = MonoTextStyle::new(&ascii::FONT_6X10, BinaryColor::On);
+        let style = MonoTextStyle::new(&iso_8859_15::FONT_6X10, BinaryColor::On);
         Text::with_baseline(
             "No player found",
             Point::new(5 + 3 + 24, 3),

--- a/src/providers/sysinfo.rs
+++ b/src/providers/sysinfo.rs
@@ -10,7 +10,7 @@ use num_traits::{pow, Pow};
 use config::Config;
 use embedded_graphics::{
     geometry::Point,
-    mono_font::{ascii, MonoTextStyle},
+    mono_font::{iso_8859_15, MonoTextStyle},
     pixelcolor::BinaryColor,
     primitives::{Primitive, PrimitiveStyle, Rectangle},
     text::{renderer::TextRenderer, Baseline, Text},
@@ -220,7 +220,7 @@ impl Sysinfo {
         text: String,
         fill: f64,
     ) -> Result<()> {
-        let style = MonoTextStyle::new(&ascii::FONT_4X6, BinaryColor::On);
+        let style = MonoTextStyle::new(&iso_8859_15::FONT_4X6, BinaryColor::On);
         let metrics = style.measure_string(&text, Point::zero(), Baseline::Top);
 
         let slot_y = slot * 8 + 1;

--- a/src/render/notifications.rs
+++ b/src/render/notifications.rs
@@ -15,7 +15,7 @@ use crate::render::{
     util::ProgressBar,
 };
 use embedded_graphics::{
-    mono_font::{ascii, MonoFont, MonoTextStyle},
+    mono_font::{iso_8859_15, MonoFont, MonoTextStyle},
     text::Text,
 };
 use futures_core::stream::Stream;
@@ -73,7 +73,7 @@ impl ContentProvider for Notification {
         let progress = ProgressBar::new(origin, self.ticks as f32);
 
         // TODO: Remove hardcoded font
-        let style = MonoTextStyle::new(&ascii::FONT_6X10, BinaryColor::On);
+        let style = MonoTextStyle::new(&iso_8859_15::FONT_6X10, BinaryColor::On);
 
         Ok(try_stream! {
             for i in 0..self.ticks {
@@ -121,7 +121,7 @@ impl<'a> NotificationBuilder<'a> {
     }
 
     fn font(&self) -> &'a MonoFont {
-        self.font.unwrap_or(&ascii::FONT_6X10)
+        self.font.unwrap_or(&iso_8859_15::FONT_6X10)
     }
 
     fn offset(&self) -> Size {

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -3,7 +3,7 @@ use apex_hardware::BitVec;
 use embedded_graphics::{
     draw_target::DrawTarget,
     geometry::{OriginDimensions, Point, Size},
-    mono_font::{ascii::FONT_6X10, MonoFont, MonoTextStyle, MonoTextStyleBuilder},
+    mono_font::{iso_8859_15::FONT_6X10, MonoFont, MonoTextStyle, MonoTextStyleBuilder},
     pixelcolor::BinaryColor,
     text::{renderer::TextRenderer, Baseline, Text},
     Drawable, Pixel,


### PR DESCRIPTION
This recreates #53 by @lucasgranberg and changes the font from `ascii` to `iso_8859_15` as its a strict superset. This should fix a lot of special characters.