### PR TITLE
Added support for config in standard config directories.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ apex-engine = { path = "./apex-engine", optional = true }
 sysinfo = { version = "0.27.7", optional = true }
 lazy_static = "1.4.0"
 image  = { version = "0.24.6", optional = true }
+dirs = "5.0.1"
 
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="<PRODUCT ID HERE>
 
 The default configuration is in `settings.toml`.
 This repository ships with a default configuration that covers most parts and contains documentation for the important keys.
+The program will look for configuration first in the platform-specific `$USER_CONFIG_DIR/apex-tux/`, then in the current working directory.
+You can also override specific settings with `APEX_*` environment variables.
 
 You can also run the software to find errors on configuration and to decide what is the right setup you need:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,9 +75,16 @@ pub async fn main() -> Result<()> {
     let mut device = Engine::new().await?;
 
     let mut settings = config::Config::default();
+    // Add in `$USER_CONFIG_DIR/apex-tux/settings.toml`
+    if let Some(user_config_dir) = dirs::config_dir() {
+        settings.merge(
+            config::File::with_name(&user_config_dir.join("apex-tux/settings").to_string_lossy())
+                .required(false),
+        )?;
+    };
     settings
         // Add in `./settings.toml`
-        .merge(config::File::with_name("settings"))?
+        .merge(config::File::with_name("settings").required(false))?
         // Add in settings from the environment (with a prefix of APEX)
         // Eg.. `APEX_DEBUG=1 ./target/app` would set the `debug` key
         .merge(config::Environment::with_prefix("APEX_"))?;


### PR DESCRIPTION
This PR makes it so the program will load the user config from the standard directory for their OS.

This could be improved with better logging of which config files were (or were not) loaded, but I couldn't find a clean way to implement that.