### PR TITLE
Changed readme twice, see description

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This currently supports the following devices:
 
 - Apex Pro
 - Apex 5
-- Apex 7 (untested)
+- Apex 7
 
 Other devices may be compatible and all that is needed is to add the ID to apex-hardware/src/usb.rs.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="<PRODUCT ID HERE>
 
 - Install Rust **nightly** using [rustup](https://rustup.rs/)
 - Install required dependencies
-  - For Ubuntu: `sudo apt install libssl-dev dbus-dev libusb-1.0-0-dev`
+  - For Ubuntu: `sudo apt install libssl-dev libdbus-1-dev libusb-1.0-0-dev`
 - Clone the repository: `git clone git@github.com:not-jan/apex-tux.git`
 - Change the directory into the repository: `cd apex-tux`
 - Compile the app using the features you want


### PR DESCRIPTION
I have made two changes to the readme:
1. changed the list of supported devices because I have tested it on Apex 7 and it works
2. changed the install command for installing the dependencies on Ubuntu, i removed dbus-dev and replaced it with libdbus-1-dev 

dbus-dev is not found by apt on installation and when building with the command in issue #60, I get an error message telling me I have to install libdbus-1-dev. After installing libdbus-1-dev it builds fine for me.

And a very quick idea: maybe the command given in issue #60 should be added to the readme until linkme gets fixed.