### PR TITLE
Fix the simulator not compiling

### DIFF
--- a/apex-simulator/Cargo.toml
+++ b/apex-simulator/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.45"
 apex-hardware = { path = "../apex-hardware" }
 embedded-graphics = "0.8"
-embedded-graphics-simulator = "0.3.0"
+embedded-graphics-simulator = "0.8.0"
 log = "0.4.14"
 tokio = {version = "1", features=["time", "net", "macros", "rt-multi-thread", "sync"]}
 apex-input = { path = "../apex-input"}


### PR DESCRIPTION
Hi, I recently tried the simulator, because I wanted to try some things, and I didn't have my keyboard with me, however, it wouldn't compile because the repo used `embedded-graphics` 0.8, while the simulator was on 0.3