### PR TITLE
README.md: add instructions to run as systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,14 @@ You may change sources by pressing **Alt+Shift+A** or **Alt+Shift+D** (This migh
 
 ## Autostarting
 
+Hotkey support requires autostarting under an interactive daemon, i.e. by your Desktop Environment. You can also build without the `hotkey` feature and run it as a systemd service.
+
+### Desktop Environment
+
 To start on boot the binary must be started under an interactive daemon, i.e. by your Desktop Environment. A systemd service will fail unless compiled without hotkey support. Most DEs support the following method/path but you may have to find your equivalent.
 
--Create `apex-tux.desktop` in `~/.config/autostart`  
--Edit `apex-tux.desktop` to contain:
+- Create `apex-tux.desktop` in `~/.config/autostart`  
+- Edit `apex-tux.desktop` to contain:
 ```shell
 [Desktop Entry]
 Exec=/path/to/apex-tux/apex-tux
@@ -165,6 +169,29 @@ Path=/path/to/apex-tux
 Terminal=true
 Type=Application
 ```
+- Replace path to the apex-tux executable accordingly
+
+### Systemd service
+
+- Create `apex-tux.service` in `/lib/systemd/system/`
+- Edit `apex-tux.service` to contain:
+```ini
+[Unit]
+Description=Linux support for the Apex series OLED screens
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/bash -c '( cd /path/to/apex-tux; /path/to/apex-tux/target/release/apex-tux ; )'
+Restart=on-abort
+User=YOUR_USERNAME
+
+[Install]
+WantedBy=multi-user.target
+```
+- Replace `YOUR_USERNAME` and `/path/to/apex-tux` path accordingly
+- Enable and start the systemd service by running: `systemctl enable --now apex-tux.service`
+
 
 ## Development
 


### PR DESCRIPTION
I don't need hotkey support and set this to start as a systemd service.

I thought I'd share how I did this and create a PR for README.md:

```sh
$ systemctl status apex-tux.service 
● apex-tux.service - prevent my fancy oled keyboard from burn-in
     Loaded: loaded (/usr/lib/systemd/system/apex-tux.service; enabled; preset: disabled)
     Active: active (running) since Wed 2026-06-17 21:24:14 JST; 14min ago
 Invocation: 8751c06e2ecd449c82dc1b5ecac9b384
   Main PID: 30831 (bash)
      Tasks: 36 (limit: 76921)
     Memory: 5.4M (peak: 7M)
        CPU: 2.388s
     CGroup: /system.slice/apex-tux.service
             ├─30831 /usr/bin/bash -c "( cd /home/flo/apex-tux/; /home/flo/apex-tux/target/release/apex-tux ; )"
             └─30841 /home/flo/apex-tux/target/release/apex-tux

 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO]         nvme Composite KINGSTON SNV2S4000G temp1: 38.85°C (max: 38.85°C / critical: 78.85°C)
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO]         nvme Sensor 1 CT2000P5PSSD8 temp2: 31.85°C (max: 31.85°C)
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO]         nvme Sensor 2 KINGSTON SNV2S4000G temp3: 56.85°C (max: 56.85°C)
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO]         pch_cannonlake temp1: 59°C (max: 59°C)
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO] Registering MPRIS2 display source.
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO] Registering Clock display source.
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO] Registering DBUS notification source.
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [ERROR] Using X11 for dbus-daemon autolaunch was disabled at compile time, set your DBUS_SESSION_BUS_ADDRESS instead
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO] Found 4 registered providers
 6月 17 21:24:14 i9 bash[30841]: 12:24:14 [INFO] Trying to connect to DBUS with player preference: None
```